### PR TITLE
Move "i" tag creation to `decodeNamedCharacterReference` function

### DIFF
--- a/index.dom.js
+++ b/index.dom.js
@@ -1,14 +1,19 @@
 /// <reference lib="dom" />
 
-/* eslint-env browser */
-
-const element = document.createElement('i')
+/**
+ * @type {HTMLElement | null}
+ */
+let element = null
 
 /**
  * @param {string} value
  * @returns {string|false}
  */
 export function decodeNamedCharacterReference(value) {
+  if (!element) {
+    element = document.createElement('i')
+  }
+
   const characterReference = '&' + value + ';'
   element.innerHTML = characterReference
   const char = element.textContent


### PR DESCRIPTION
In file `index.dom.js` on line 5 there is a statement

```javascript
const element = document.createElement('i')
```

Because this statement is at the top of the module, I get an error

```
ReferenceError: document is not defined
```

when rendering React on the server. I use `react-markdown` which through some dependency chain uses `decode-named-character-reference`.

I propose the first commit to be used to resolve this.