### PR TITLE
Add entry point for nextjs project

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
       "deno": "./index.js",
       "react-native": "./index.js",
       "worker": "./index.js",
+      "edge-light": "./index.js",
       "browser": "./index.dom.js",
       "default": "./index.js"
     }


### PR DESCRIPTION
Due to Next.js's bundling strategy, it accidentally includes [index.dom.js](https://github.com/wooorm/decode-named-character-reference/blob/main/index.dom.js) in the edge-runtime code. As a result, top-level access to `document` triggers an error. I’ve created a minimal reproduction repo [here](https://github.com/ioslh/nextjs-edge-import) — simply run `pnpm build` to see the error in action.

After digging deeper into Next.js's module resolution strategy, I found that when bundling edge-side code, the highest-priority entry point is [edge-light](https://github.com/vercel/next.js/blob/v15.2.1/packages/next/src/build/webpack-config-rules/resolve.ts#L8). However, your repository doesn’t define this custom entry point, and for some reason, it falls back to the `browser`, which causes the issue.

To address this, I’m proposing an alternative fix(other than [this one](https://github.com/wooorm/decode-named-character-reference/pull/5) ) in this PR: explicitly providing an entry point tailored for Next.js.