### PR TITLE
Add `workerd` condition for Cloudfalre workers

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "exports": {
     "deno": "./index.js",
+    "workerd": "./index.js",
     "edge-light": "./index.js",
     "react-native": "./index.js",
     "worker": "./index.js",


### PR DESCRIPTION
The condition name for Cloudflare workers is `workerd`, it seems to ignore `worker`