### PR TITLE
Add `convex` condition

### DIFF
--- a/index.dom.js
+++ b/index.dom.js
@@ -20,8 +20,6 @@ export function decodeNamedCharacterReference(value) {
   // reference to decode was not a semicolon (`&semi;`), we can assume that the
   // matching was not complete.
   if (
-    // @ts-expect-error: TypeScript is wrong that `textContent` on elements can
-    // yield `null`.
     character.charCodeAt(character.length - 1) === 59 /* `;` */ &&
     value !== 'semi'
   ) {
@@ -30,7 +28,5 @@ export function decodeNamedCharacterReference(value) {
 
   // If the decoded string is equal to the input, the character reference was
   // not valid.
-  // @ts-expect-error: TypeScript is wrong that `textContent` on elements can
-  // yield `null`.
   return character === characterReference ? false : character
 }

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "xo": "^1.0.0"
   },
   "exports": {
-    "deno": "./index.js",
     "convex": "./index.js",
+    "deno": "./index.js",
     "edge-light": "./index.js",
     "react-native": "./index.js",
     "worker": "./index.js",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "exports": {
     "deno": "./index.js",
+    "convex": "./index.js",
     "edge-light": "./index.js",
     "react-native": "./index.js",
     "worker": "./index.js",


### PR DESCRIPTION
The convex runtime is similar to "browser" for many packages, but it doesn't have `document` defined.
Convex bundling will provide "convex" as a selector and "browser" as a fallback. 
This change allows Convex to bundle `>= @blocknote/core@0.38` which depends on this via some other dependency indirection.